### PR TITLE
Add actions_deploy_key in place of github_token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,5 +75,5 @@ jobs:
     - name: Deploy to gh pages
       uses: peaceiris/action-gh-pages@v3
       with:
-        github_token: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
+        github_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_dir: ./build


### PR DESCRIPTION
A deploy key with public/private key is used