### PR TITLE
Fix peaceiris repo spelling mistake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
         path: ./build
        
     - name: Deploy to gh pages
-      uses: peaceiris/action-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v3
       with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_dir: ./build


### PR DESCRIPTION
Change action to actions in the deploy to gh pages step of workflows/main.yml