### PR TITLE
Change deploy_token back to github_token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,5 +75,5 @@ jobs:
     - name: Deploy to gh pages
       uses: peaceiris/actions-gh-pages@v3
       with:
-        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build


### PR DESCRIPTION
Change deploy_token to github_token as gh-pages is  taking longer time than expected to build. Could be a possible fix for the issue